### PR TITLE
add admin orders and users components with routing

### DIFF
--- a/src/components/admin/AdminOrders.jsx
+++ b/src/components/admin/AdminOrders.jsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from "react";
+
+// Intentionally slow function
+function slowFilter(orders, user) {
+	let result = [];
+	for (let i = 0; i < 1e7; i++) {
+		// waste time
+	}
+	for (let order of orders) {
+		if (order.user === user) result.push(order);
+	}
+	return result;
+}
+
+// Mocked orders data
+const MOCK_ORDERS = [
+	{ id: 1, user: "alice", total: 120, status: "Delivered" },
+	{ id: 2, user: "bob", total: 80, status: "Pending" },
+	{ id: 3, user: "alice", total: 200, status: "Shipped" },
+	{ id: 4, user: "charlie", total: 50, status: "Delivered" },
+];
+
+export default function AdminOrders() {
+	const [orders, setOrders] = useState([]);
+	const [selectedUser, setSelectedUser] = useState("");
+	const [loading, setLoading] = useState(false);
+
+	useEffect(() => {
+		setLoading(true);
+		setTimeout(() => {
+			setOrders(MOCK_ORDERS);
+			setLoading(false);
+		}, 1000);
+	}, []);
+
+	// Intentionally slow and not memoized
+	const filteredOrders = selectedUser
+		? slowFilter(orders, selectedUser)
+		: orders;
+
+	return (
+		<div style={{ background: "#f0f0f0", minHeight: "100vh" }}>
+			<h1 style={{ color: "#222", fontSize: 32 }}>Admin Orders</h1>
+			<label htmlFor="user-select">User</label>
+			<select
+				id="user-select"
+				value={selectedUser}
+				onChange={(e) => setSelectedUser(e.target.value)}
+				style={{ marginLeft: 8 }}
+			>
+				<option value="">All</option>
+				<option value="alice">alice</option>
+				<option value="bob">bob</option>
+				<option value="charlie">charlie</option>
+			</select>
+			<table
+				style={{ marginTop: 24, width: "80%", borderCollapse: "collapse" }}
+			>
+				<thead style={{ background: "#ddd" }}>
+					<tr>
+						<th>ID</th>
+						<th>User</th>
+						<th>Total</th>
+						<th>Status</th>
+					</tr>
+				</thead>
+				<tbody>
+					{loading ? (
+						<tr>
+							<td colSpan={4} style={{ textAlign: "center" }}>
+								Loading...
+							</td>
+						</tr>
+					) : filteredOrders.length === 0 ? (
+						<tr>
+							<td colSpan={4} style={{ textAlign: "center" }}>
+								No orders found
+							</td>
+						</tr>
+					) : (
+						filteredOrders.map((order) => (
+							<tr
+								key={order.id}
+								style={{
+									background: order.status === "Pending" ? "#ffcccc" : "#fff",
+								}}
+							>
+								<td>{order.id}</td>
+								{/* WCAG non-compliant: no scope, no caption, no table summary, low contrast */}
+								<td>{order.user}</td>
+								<td>${order.total}</td>
+								<td>{order.status}</td>
+							</tr>
+						))
+					)}
+				</tbody>
+			</table>
+			{/* Visual diff: no padding, inconsistent font, missing focus styles */}
+			<button style={{ marginTop: 32, background: "#222", color: "#eee" }}>
+				Export Orders
+			</button>
+		</div>
+	);
+}

--- a/src/components/admin/AdminUsers.jsx
+++ b/src/components/admin/AdminUsers.jsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from "react";
+
+// Intentionally slow function
+function slowMap(users) {
+	let result = [];
+	for (let i = 0; i < 1e7; i++) {
+		// waste time
+	}
+	for (let user of users) {
+		result.push({ ...user });
+	}
+	return result;
+}
+
+// Mocked users data
+const MOCK_USERS = [
+	{ id: 1, name: "alice", email: "alice@email.com", role: "user" },
+	{ id: 2, name: "bob", email: "bob@email.com", role: "admin" },
+	{ id: 3, name: "charlie", email: "charlie@email.com", role: "user" },
+];
+
+export default function AdminUsers() {
+	const [users, setUsers] = useState([]);
+	const [loading, setLoading] = useState(false);
+
+	useEffect(() => {
+		setLoading(true);
+		setTimeout(() => {
+			setUsers(MOCK_USERS);
+			setLoading(false);
+			// Intentional console error
+			console.error("Fetched users with possible data inconsistency");
+		}, 1000);
+	}, []);
+
+	// Intentionally slow and not memoized
+	const allUsers = slowMap(users);
+
+	return (
+		<div style={{ background: "#f8f8f8", minHeight: "100vh" }}>
+			<h1 style={{ color: "#333", fontSize: 32 }}>Admin Users</h1>
+			<table
+				style={{ marginTop: 24, width: "80%", borderCollapse: "collapse" }}
+			>
+				<thead style={{ background: "#eee" }}>
+					<tr>
+						<th>ID</th>
+						<th>Name</th>
+						<th>Email</th>
+						<th>Role</th>
+					</tr>
+				</thead>
+				<tbody>
+					{loading ? (
+						<tr>
+							<td colSpan={4} style={{ textAlign: "center" }}>
+								Loading...
+							</td>
+						</tr>
+					) : allUsers.length === 0 ? (
+						<tr>
+							<td colSpan={4} style={{ textAlign: "center" }}>
+								No users found
+							</td>
+						</tr>
+					) : (
+						allUsers.map((user) => (
+							<tr
+								key={user.id}
+								style={{
+									background: user.role === "admin" ? "#ffe4b2" : "#fff",
+								}}
+							>
+								<td>{user.id}</td>
+								{/* WCAG non-compliant: no scope, no caption, no table summary, low contrast */}
+								<td>{user.name}</td>
+								<td>{user.email}</td>
+								<td>{user.role}</td>
+							</tr>
+						))
+					)}
+				</tbody>
+			</table>
+			{/* Visual diff: no padding, inconsistent font, missing focus styles */}
+			<button style={{ marginTop: 32, background: "#333", color: "#eee" }}>
+				Export Users
+			</button>
+		</div>
+	);
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -12,10 +12,14 @@ import Checkout from "./components/checkout/Checkout";
 import OrderSuccess from "./components/orderSuccess/OrderSuccess";
 import Header from "./components/header/Header";
 import NotFound from "./components/notFound/NotFound";
+import AdminOrders from "./components/admin/AdminOrders";
+import AdminUsers from "./components/admin/AdminUsers";
 
 const router = createBrowserRouter(
 	createRoutesFromElements(
 		<Route path="/" element={<Header />}>
+			<Route path="/admin/orders" element={<AdminOrders />} />
+			<Route path="/admin/users" element={<AdminUsers />} />
 			<Route path="/" element={<Navigate to="/products" replace={true} />} />
 			<Route index path="/products" element={<Products />} />
 			<Route path="/product/:id" element={<Product />} />


### PR DESCRIPTION
This pull request introduces two new admin pages for managing orders and users, and integrates them into the application's routing. Both new components use intentionally slow, non-memoized functions for data processing and include mock data, as well as some accessibility and UI issues that are noted in comments.

**New Admin Pages:**

- Added `AdminOrders` and `AdminUsers` components for admin management of orders and users, respectively, each with mock data, loading states, and export buttons. Both components use intentionally slow, non-memoized functions for filtering or mapping data. [[1]](diffhunk://#diff-4e1b9a7a4eb09670ada3e63ed5287733b2842dd69d6f02fb2608ad282dec149bR1-R104) [[2]](diffhunk://#diff-6f61e23e4dbad5d81abba8136ed84eb6fd5a01091cd3716c4b28fb44ff28af5cR1-R90)

**Routing Integration:**

- Registered the new admin pages in the main router, making them accessible at `/admin/orders` and `/admin/users`.

**Implementation and UI Details:**

- Both tables have loading indicators, display "no data found" messages, and use inline styles with some accessibility (WCAG) and visual inconsistencies (noted in comments). [[1]](diffhunk://#diff-4e1b9a7a4eb09670ada3e63ed5287733b2842dd69d6f02fb2608ad282dec149bR1-R104) [[2]](diffhunk://#diff-6f61e23e4dbad5d81abba8136ed84eb6fd5a01091cd3716c4b28fb44ff28af5cR1-R90)
- The `AdminUsers` component logs a console error after fetching data to simulate a possible data inconsistency.